### PR TITLE
Add a CDN_DEBUG setting, which default to app.debug

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,6 +106,9 @@ settings to control the behaviour of Flask-CDN. None of the settings are
 required.
 
 =========================== ===================================================
+`CDN_DEBUG`                 Activate Debug mode to return relative url rather
+                            than CDN enabled ones.
+                            **Default:** `app.debug`
 `CDN_DOMAIN`                Set the base domain for your CDN here.
                             **Default:** `None`
 `CDN_HTTPS`                 Specifies whether or not to serve your assets over

--- a/flask_cdn.py
+++ b/flask_cdn.py
@@ -19,7 +19,7 @@ def url_for(endpoint, **values):
     """
     app = current_app
 
-    if app.debug:
+    if app.config['CDN_DEBUG']:
         return flask_url_for(endpoint, **values)
 
     if endpoint == 'static' or endpoint.endswith('.static'):
@@ -68,7 +68,8 @@ class CDN(object):
             self.init_app(app)
 
     def init_app(self, app):
-        defaults = [('CDN_DOMAIN', None),
+        defaults = [('CDN_DEBUG', app.debug),
+                    ('CDN_DOMAIN', None),
                     ('CDN_HTTPS', None),
                     ('CDN_TIMESTAMP', True)]
 

--- a/tests/test_flask_cdn.py
+++ b/tests/test_flask_cdn.py
@@ -15,6 +15,10 @@ class DefaultsTest(unittest.TestCase):
 
         CDN(self.app)
 
+    def test_debug_default(self):
+        """ Tests CDN_DEBUG default value is correctly set. """
+        self.assertEquals(self.app.config['CDN_DEBUG'], False)
+
     def test_domain_default(self):
         """ Tests CDN_DOMAIN default value is correctly set. """
         self.assertEquals(self.app.config['CDN_DOMAIN'], None)
@@ -64,7 +68,7 @@ class UrlTests(unittest.TestCase):
 
     def test_url_for_debug(self):
         """ Tests app.debug correctly affects generated URLs. """
-        self.app.debug = True
+        self.app.config['CDN_DEBUG'] = True
         ufs = "{{ url_for('static', filename='bah.js') }}"
 
         exp = '/static/bah.js'


### PR DESCRIPTION
This change uncouples the main debug flag with the one used by
Flask-CDN to ease the testing process.

I've seen after coding that there's another PR for the same issue with a slighly different implementation.
Since the PR seems stale and don't apply to the source tree anymore, I decided to push this one instead.
Sorry for the duplicate!